### PR TITLE
Correct host check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require": {
         "php": ">=7.1",
         "egulias/email-validator": "^2.1.11",
-        "illuminate/validation": "^5.8"
+        "illuminate/validation": "^5.8",
+        "symfony/polyfill-intl-idn": "^1.12"
     },
     "require-dev": {
         "orchestra/testbench": "*",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1",
-        "egulias/email-validator": "^2.1",
+        "egulias/email-validator": "^2.1.11",
         "illuminate/validation": "^5.8"
     },
     "require-dev": {

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -4,5 +4,6 @@ return [
     'html5' => 'The value must be a valid email address.',
     'rfc' => 'The value must be a valid email address.',
     'host' => 'The value must be a valid email address.',
+    'nohost' => 'The value must be a valid email address.',
     'mx' => 'The value must be a valid email address.',
 ];

--- a/src/Rules/RealEmail.php
+++ b/src/Rules/RealEmail.php
@@ -65,19 +65,31 @@ final class RealEmail implements Rule
             }
         }
 
-        $host = (string) substr($email, strrpos($email, '@') + 1);
-
-        if ($this->hasConstraint('mx') && ! $this->checkMX($host)) {
-            $this->messages[] = __('realEmailValidation::messages.mx');
+        $hostSeparatorPosition = strrpos($email, '@');
+        if ($hostSeparatorPosition === FALSE || $hostSeparatorPosition === strlen($email) - 1) {
+            $this->messages[] = __('realEmailValidation::messages.nohost');
             if ($this->bail) {
                 return false;
             }
-        }
+        } else {
+            $emailTail = (string) substr($email, $hostSeparatorPosition + 1);
+            $host = idn_to_ascii($emailTail);
+            if (substr($host, -1) !== '.') {
+                $host .= '.';
+            }
 
-        if ($this->hasConstraint('host') && ! $this->checkHost($host)) {
-            $this->messages[] = __('realEmailValidation::messages.host');
-            if ($this->bail) {
-                return false;
+            if ($this->hasConstraint('mx') && ! $this->checkMX($host)) {
+                $this->messages[] = __('realEmailValidation::messages.mx');
+                if ($this->bail) {
+                    return false;
+                }
+            }
+
+            if ($this->hasConstraint('host') && ! $this->checkHost($host)) {
+                $this->messages[] = __('realEmailValidation::messages.host');
+                if ($this->bail) {
+                    return false;
+                }
             }
         }
 
@@ -110,7 +122,7 @@ final class RealEmail implements Rule
      */
     private function checkMX(string $host): bool
     {
-        return $host !== '' && checkdnsrr($host, 'MX');
+        return checkdnsrr($host, 'MX');
     }
 
     /**
@@ -118,7 +130,6 @@ final class RealEmail implements Rule
      */
     private function checkHost(string $host): bool
     {
-        return $host !== ''
-            && ($this->checkMX($host) || (checkdnsrr($host, 'A') || checkdnsrr($host, 'AAAA')));
+        return $this->checkMX($host) || (checkdnsrr($host, 'A') || checkdnsrr($host, 'AAAA'));
     }
 }

--- a/src/Rules/RealEmail.php
+++ b/src/Rules/RealEmail.php
@@ -130,6 +130,6 @@ final class RealEmail implements Rule
      */
     private function checkHost(string $host): bool
     {
-        return $this->checkMX($host) || (checkdnsrr($host, 'A') || checkdnsrr($host, 'AAAA'));
+        return checkdnsrr($host, 'A') || checkdnsrr($host, 'AAAA') || $this->checkMX($host);
     }
 }

--- a/src/Rules/RealEmail.php
+++ b/src/Rules/RealEmail.php
@@ -73,7 +73,7 @@ final class RealEmail implements Rule
             }
         } else {
             $emailTail = (string) substr($email, $hostSeparatorPosition + 1);
-            $host = idn_to_ascii($emailTail);
+            $host = idn_to_ascii($emailTail, 0, INTL_IDNA_VARIANT_UTS46);
             if (substr($host, -1) !== '.') {
                 $host .= '.';
             }

--- a/src/Rules/RealEmail.php
+++ b/src/Rules/RealEmail.php
@@ -66,7 +66,7 @@ final class RealEmail implements Rule
         }
 
         $hostSeparatorPosition = strrpos($email, '@');
-        if ($hostSeparatorPosition === FALSE || $hostSeparatorPosition === strlen($email) - 1) {
+        if ($hostSeparatorPosition === false || $hostSeparatorPosition === strlen($email) - 1) {
             $this->messages[] = __('realEmailValidation::messages.nohost');
             if ($this->bail) {
                 return false;

--- a/tests/Rules/RealEmailTest.php
+++ b/tests/Rules/RealEmailTest.php
@@ -38,6 +38,18 @@ class RealEmailTest extends TestCase
 
     /**
      * @test
+     * @dataProvider invalidEmailsForMissingHostCheckProvider
+     * @group network
+     */
+    public function it_fails_on_missing_host($invalidEmail)
+    {
+        $rule = new RealEmail(['host']);
+
+        $this->assertFalse($rule->passes('random_input_name', $invalidEmail));
+    }
+
+    /**
+     * @test
      * @dataProvider invalidEmailForRfcCheckProvider
      */
     public function it_fails_by_rfc_check($invalidEmail)
@@ -72,6 +84,15 @@ class RealEmailTest extends TestCase
         return [
             ['example@gmail.con'],
             ['example@gmail.ocm'],
+        ];
+    }
+
+    public function invalidEmailsForMissingHostCheckProvider()
+    {
+        return [
+            ['example'],
+            ['example@'],
+            ['gmail.com'],
         ];
     }
 

--- a/tests/Rules/RealEmailTest.php
+++ b/tests/Rules/RealEmailTest.php
@@ -50,6 +50,18 @@ class RealEmailTest extends TestCase
 
     /**
      * @test
+     * @dataProvider invalidEmailsForMxCheckProvider
+     * @group network
+     */
+    public function it_fails_on_invalid_mx($invalidEmail)
+    {
+        $rule = new RealEmail(['mx']);
+
+        $this->assertFalse($rule->passes('random_input_name', $invalidEmail));
+    }
+
+    /**
+     * @test
      * @dataProvider invalidEmailForRfcCheckProvider
      */
     public function it_fails_by_rfc_check($invalidEmail)
@@ -93,6 +105,14 @@ class RealEmailTest extends TestCase
             ['example'],
             ['example@'],
             ['gmail.com'],
+        ];
+    }
+
+    public function invalidEmailsForMxCheckProvider()
+    {
+        return [
+            ['example@gmail.con'],
+            ['example@gmail.ocm'],
         ];
     }
 


### PR DESCRIPTION
The existing host check doesn't convert domain names with umlauts to the ascii equivalent before performing DNS checks.

The check also uses relative domain names, instead of fully-qualified domain names (FQDN). A FQDN ends with a dot, this helps speed up resolution of domain records.
[http://www.dns-sd.org/trailingdotsindomainnames.html](http://www.dns-sd.org/trailingdotsindomainnames.html)